### PR TITLE
Template customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ export default {
 | `visibleValue`        | Boolean   |  false        |                                             |
 | `valueCountUp`        | Boolean   |  false        |                                             |
 | `valueCountUpDuration`| Number    |  2000         | Number in milliseconds                      |
+| `valueCountUpDelay`   | Number    |  500          | Percent count-up delay (for changing values)|
 | `customPercentSize`   | Number    |  40           | Percent font size in pixels (max 60)        |
 | `passTextAsHtml`      | Boolean   |  false        | Allows to add simple html into label        |
 | `customText`          | String    |  ''           | Label value                                 |

--- a/README.md
+++ b/README.md
@@ -30,18 +30,24 @@ export default {
 
 ## Props
 
-| Props Name          | Type      | Default Value |Description                   | 
-|---------------------|-----------|---------------|------------------------------|
-| `percent`           | Number    |  0            |                              |
-| `foregroundColor`   | String    |  '#1993ff'    |                              |
-| `backgroundColor`   | String    |  '#ecf6ff'    |                              |
-| `strokeWidth`       | Number    |  10           |                              |
-| `radius`            | Number    |  85           |                              |
-| `width`             | Number    |  200          |                              |
-| `height`            | Number    |  200          |                              |
-| `visibleValue`      | Boolean   |  false        |                              |
-| `emptyText`         | String    |  ''           |                              |
-| `classValue`        | String    |  ''           |                              |
+| Props Name            | Type      | Default Value |Description                                  | 
+|-----------------------|-----------|---------------|---------------------------------------------|
+| `percent`             | Number    |  0            |                                             |
+| `foregroundColor`     | String    |  '#1993ff'    |                                             |
+| `backgroundColor`     | String    |  '#ecf6ff'    |                                             |
+| `strokeWidth`         | Number    |  10           |                                             |
+| `radius`              | Number    |  85           |                                             |
+| `width`               | Number    |  200          |                                             |
+| `height`              | Number    |  200          |                                             |
+| `classValue`          | String    |  ''           |                                             |
+| `visibleValue`        | Boolean   |  false        |                                             |
+| `valueCountUp`        | Boolean   |  false        |                                             |
+| `valueCountUpDuration`| Number    |  2000         | Number in milliseconds                      |
+| `customPercentSize`   | Number    |  40           | Percent font size in pixels                 |
+| `passTextAsHtml`      | Boolean   |  false        | Allows to add simple html into label        |
+| `customText`          | String    |  ''           | Label value                                 |
+| `customTextColor`     | String    |  '#1993ff'    | Valid HEX color code or CSS color for label |
+| `customTextSize`      | Number    |  15           | Label font size in pixels                   |
 
 -----
 

--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ export default {
 | `visibleValue`        | Boolean   |  false        |                                             |
 | `valueCountUp`        | Boolean   |  false        |                                             |
 | `valueCountUpDuration`| Number    |  2000         | Number in milliseconds                      |
-| `customPercentSize`   | Number    |  40           | Percent font size in pixels                 |
+| `customPercentSize`   | Number    |  40           | Percent font size in pixels (max 60)        |
 | `passTextAsHtml`      | Boolean   |  false        | Allows to add simple html into label        |
 | `customText`          | String    |  ''           | Label value                                 |
 | `customTextColor`     | String    |  '#1993ff'    | Valid HEX color code or CSS color for label |
-| `customTextSize`      | Number    |  15           | Label font size in pixels                   |
+| `customTextSize`      | Number    |  15           | Label font size in pixels (max 22)          |
 
 -----
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -26,6 +26,8 @@
           :percent="percent"
           :visibleValue="true"
           :foregroundColor="'purple'"
+          :value-count-up="true"
+          :value-count-up-duration="3000"
           />
       </div>
       <div class="column">

--- a/src/App.vue
+++ b/src/App.vue
@@ -26,7 +26,6 @@
           :percent="percent"
           :visibleValue="true"
           :foregroundColor="'purple'"
-          :emptyText="'N/A'"
           />
       </div>
       <div class="column">

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,44 +2,44 @@
   <div>
     <div class="columns">
       <div class="column">
-        <DoughnutChart 
-          :percent="percent" 
+        <DoughnutChart
+          :percent="percent"
           :visibleValue="true"/>
       </div>
       <div class="column">
-        <DoughnutChart 
-          :percent="percent" 
-          :visibleValue="true" 
+        <DoughnutChart
+          :percent="percent"
+          :visibleValue="true"
           foregroundColor="green"
           backgroundColor="#d3fde2"
           :strokeWidth="20"/>
       </div>
       <div class="column">
-        <DoughnutChart 
-          :percent="percent" 
-          :visibleValue="true" 
+        <DoughnutChart
+          :percent="percent"
+          :visibleValue="true"
           foregroundColor="red"
           :strokeWidth="30"/>
       </div>
       <div class="column">
-        <DoughnutChart 
-          :percent="percent" 
-          :visibleValue="true" 
+        <DoughnutChart
+          :percent="percent"
+          :visibleValue="true"
           :foregroundColor="'purple'"
           :emptyText="'N/A'"
           />
       </div>
       <div class="column">
-        <DoughnutChart 
-          :percent="percent" 
-          :visibleValue="true" 
+        <DoughnutChart
+          :percent="percent"
+          :visibleValue="true"
           :foregroundColor="'black'"
           :customText="'My value is over <br/> 9000'"
           />
     </div>
   </div>
     <div class="centered-div">
-      <input type="range" min="0" step="1" max="100" v-model="percent"><br> 
+      <input type="range" min="0" step="1" max="100" v-model="percent"><br>
       <h3 class="subtitle">{{percent}}%</h3>
     </div>
   </div>
@@ -154,6 +154,12 @@ input[type=range]:focus::-ms-fill-lower {
 }
 input[type=range]:focus::-ms-fill-upper {
   background: #ac51b5;
+}
+.column {
+  display: flex;
+  flex-flow: column nowrap;
+  align-items: center;
+  justify-content: center;
 }
 </style>
 

--- a/src/DoughnutChart.vue
+++ b/src/DoughnutChart.vue
@@ -100,18 +100,18 @@ export default {
       default: 2000,
       required: false
     },
-    customText: {
-      type: String,
-      default: ""
+    customPercentSize: {
+      type: Number,
+      default: 40,
+      required: false
     },
     passTextAsHtml: {
       type: Boolean,
       default: false
     },
-    customPercentSize: {
-      type: Number,
-      default: 40,
-      required: false
+    customText: {
+      type: String,
+      default: ""
     },
     customTextColor: {
       type: String,

--- a/src/DoughnutChart.vue
+++ b/src/DoughnutChart.vue
@@ -2,9 +2,9 @@
   <div class='doughnut_chart' style='position:relative;'>
     <svg :width='width' :height='height' viewBox='0 0 200 200' style='stroke-linecap:round;'>
       <!-- Background circle -->
-      <path :d='dBg' fill='transparent' :stroke='backgroundColor' :stroke-width='strokeWidth' />
+      <path :d='dBg' fill='transparent' :stroke="validateColor(backgroundColor) ? backgroundColor : '#ecf6ff'" :stroke-width='strokeWidth' />
       <!-- Move to start position, start drawing arc -->
-      <path :d='d' fill='transparent' :stroke='foregroundColor' :stroke-width='strokeWidth' />
+      <path :d='d' fill='transparent' :stroke="validateColor(foregroundColor) ? foregroundColor : '#1993ff'" :stroke-width='strokeWidth' />
     </svg>
     <div
         v-if='visibleValue'
@@ -154,20 +154,20 @@ export default {
       return `M ${ this.x } ${ this.y } A ${ this.radius } ${ this.radius } 0 ${ this.largeArc } 1 ${ this.endX } ${ this.endY } ${ this.z }`;
     },
     valueStyle() {
+      let percentColor = this.validateColor(this.foregroundColor) ? this.foregroundColor : '#1993ff'
       let percentSize = ( this.customPercentSize && this.customPercentSize < 60 ) ? `${ this.customPercentSize }px` : false
       return {
-        color: this.foregroundColor,
+        color: percentColor,
         fontSize: percentSize,
         margin: '0 auto'
       };
     },
     customTextStyle() {
-      let textColor = this.customTextColor ? this.customTextColor : this.foregroundColor
+      let textColor = this.validateColor(this.customTextColor) ? this.customTextColor : this.foregroundColor
       let textWidth = this.strokeWidth ? `calc(100% - ${ this.strokeWidth * 2 }px)` : 'calc(100% - 20px)'
       let textPadding = (this.strokeWidth && this.strokeWidth > 7 && this.strokeWidth <= 18) ? `0 ${ this.strokeWidth }px` : '0 10px'
       let textSize = ( this.customTextSize && this.customTextSize <= 22 ) ? `${ this.customTextSize }px` : false
       let customTopMargin = (this.strokeWidth && this.strokeWidth > 7 && this.strokeWidth <= 18) ? this.strokeWidth : 5
-
       return {
         color: textColor,
         width: textWidth,
@@ -178,6 +178,14 @@ export default {
         wordBreak: "break-all",
         wordWrap: "break-word"
       };
+    }
+  },
+  methods: {
+    validateColor(string) {
+      let s = new Option().style
+      s.color = string
+      // must match a valid css color or hex value
+      return s.color !== '' || /^#([0-9A-F]{3}){1,2}$/i.test(s.color);
     }
   }
 };

--- a/src/DoughnutChart.vue
+++ b/src/DoughnutChart.vue
@@ -82,6 +82,10 @@ export default {
       type: Number,
       default: 200
     },
+    classValue: {
+      type: String,
+      default: ""
+    },
     visibleValue: {
       type: Boolean,
       default: false
@@ -95,10 +99,6 @@ export default {
       type: Number,
       default: 2000,
       required: false
-    },
-    classValue: {
-      type: String,
-      default: ""
     },
     customText: {
       type: String,

--- a/src/DoughnutChart.vue
+++ b/src/DoughnutChart.vue
@@ -100,6 +100,11 @@ export default {
       default: 2000,
       required: false
     },
+    valueCountUpDelay: {
+      type: Number,
+      default: 500,
+      required: false
+    },
     customPercentSize: {
       type: Number,
       default: 40,
@@ -122,7 +127,7 @@ export default {
       type: Number,
       default: 15,
       required: false
-    },
+    }
   },
   data() {
     return {
@@ -204,13 +209,14 @@ export default {
   },
   watch: {
     percent() {
+      const delay = this.valueCountUpDelay ? this.valueCountUpDelay : 500
       if (this.delayTimer) {
         clearTimeout(this.delayTimer)
         this.delayTimer = null
       }
       this.delayTimer = setTimeout(() => {
         this.countUpPercent()
-      }, 500)
+      }, delay)
     }
   },
   methods: {

--- a/src/DoughnutChart.vue
+++ b/src/DoughnutChart.vue
@@ -122,11 +122,12 @@ export default {
       type: Number,
       default: 15,
       required: false
-    }
+    },
   },
   data() {
     return {
-      countingUpValue: 0
+      countingUpValue: 0,
+      delayTimer: null
     };
   },
   computed: {
@@ -199,6 +200,17 @@ export default {
   mounted() {
     if (this.valueCountUp && this.percent) {
       this.countUpPercent()
+    }
+  },
+  watch: {
+    percent() {
+      if (this.delayTimer) {
+        clearTimeout(this.delayTimer)
+        this.delayTimer = null
+      }
+      this.delayTimer = setTimeout(() => {
+        this.countUpPercent()
+      }, 500)
     }
   },
   methods: {

--- a/src/DoughnutChart.vue
+++ b/src/DoughnutChart.vue
@@ -15,30 +15,34 @@
             v-if='customText.length'
             :style='customTextStyle'
             v-html='customText'
-        ></div>
+        />
       </template>
       <template v-else>
+        <h1
+            v-if='percent'
+            :class='classValue'
+            :style='valueStyle'
+        >
+          {{ percent + '%' }}
+        </h1>
         <div
             v-if='customText.length'
             v-html='customText'
             :class='classValue'
             :style='customTextStyle'
         />
-        <p
-            v-else-if='visibleEmptyText'
-            :class='classValue'
-            :style='valueStyle'
-        >
-          {{ emptyText }}
-        </p>
-        <h1
-            v-else
-            :class='classValue'
-            :style='valueStyle'
-        >
-          {{ percent + '%' }}
-        </h1>
       </template>
+    </div>
+    <div
+        v-else-if='customText.length'
+        class='value-container'
+    >
+      <div
+          v-if='customText.length'
+          v-html='customText'
+          :class='classValue'
+          :style='customTextStyle'
+      />
     </div>
   </div>
 </template>
@@ -78,10 +82,6 @@ export default {
       type: Boolean,
       default: false
     },
-    emptyText: {
-      type: String,
-      default: ""
-    },
     classValue: {
       type: String,
       default: ""
@@ -97,6 +97,16 @@ export default {
     customPercentSize: {
       type: Number,
       default: 40,
+      required: false
+    },
+    customTextColor: {
+      type: String,
+      default: '',
+      required: false
+    },
+    customTextSize: {
+      type: Number,
+      default: 15,
       required: false
     }
   },
@@ -143,43 +153,30 @@ export default {
     d() {
       return `M ${ this.x } ${ this.y } A ${ this.radius } ${ this.radius } 0 ${ this.largeArc } 1 ${ this.endX } ${ this.endY } ${ this.z }`;
     },
-    valueFromBottom() {
-      if (this.strokeWidth < 15) {
-        return this.height / 2 - this.strokeWidth / 1.5;
-      } else {
-        return this.height / 2 - this.strokeWidth / 3;
-      }
-    },
-    valueFromLeft() {
-      if (this.strokeWidth < 15) {
-        return this.width / 2 - this.strokeWidth;
-      } else {
-        return this.width / 2 - this.strokeWidth;
-      }
-    },
     valueStyle() {
-      let percentSize = (this.customPercentSize && this.customPercentSize < 60) ? this.customPercentSize : false
+      let percentSize = ( this.customPercentSize && this.customPercentSize < 60 ) ? `${ this.customPercentSize }px` : false
       return {
         color: this.foregroundColor,
-        fontSize: `${ percentSize }px`
+        fontSize: percentSize,
+        margin: '0 auto'
       };
     },
-    visibleEmptyText() {
-      return parseInt(this.percent) === 0 && this.emptyText !== "";
-    },
     customTextStyle() {
+      let textColor = this.customTextColor ? this.customTextColor : this.foregroundColor
+      let textWidth = this.strokeWidth ? `calc(100% - ${ this.strokeWidth * 2 }px)` : 'calc(100% - 20px)'
+      let textPadding = (this.strokeWidth && this.strokeWidth > 7 && this.strokeWidth <= 18) ? `0 ${ this.strokeWidth }px` : '0 10px'
+      let textSize = ( this.customTextSize && this.customTextSize <= 22 ) ? `${ this.customTextSize }px` : false
+      let customTopMargin = (this.strokeWidth && this.strokeWidth > 7 && this.strokeWidth <= 18) ? this.strokeWidth : 5
+
       return {
-        color: this.foregroundColor,
-        width: `${ this.width - 6 * this.strokeWidth }px`,
-        height: `${ this.height / 3 }px`,
-        bottom: `${ this.height / 2 - this.strokeWidth * 3 }px`,
-        left: `${ this.valueFromLeft / 3 }px`,
-        position: "absolute",
-        verticalAlign: "middle",
+        color: textColor,
+        width: textWidth,
+        padding: textPadding,
+        margin: `-${ customTopMargin }px auto 0`,
+        textAlign: 'center',
+        fontSize: textSize,
         wordBreak: "break-all",
-        wordWrap: "break-word",
-        fontSize: "14px",
-        textAlign: "center"
+        wordWrap: "break-word"
       };
     }
   }

--- a/src/DoughnutChart.vue
+++ b/src/DoughnutChart.vue
@@ -2,10 +2,12 @@
   <div class='doughnut_chart' style='position:relative;'>
     <svg :width='width' :height='height' viewBox='0 0 200 200' style='stroke-linecap:round;'>
       <!-- Background circle -->
-      <path :d='dBg' fill='transparent' :stroke="validateColor(backgroundColor) ? backgroundColor : '#ecf6ff'"
+      <path :d='dBg' fill='transparent'
+            :stroke="(backgroundColor && validateColor(backgroundColor)) ? backgroundColor : '#ecf6ff'"
             :stroke-width='strokeWidth' />
       <!-- Move to start position, start drawing arc -->
-      <path :d='d' fill='transparent' :stroke="validateColor(foregroundColor) ? foregroundColor : '#1993ff'"
+      <path :d='d' fill='transparent'
+            :stroke="(foregroundColor && validateColor(foregroundColor)) ? foregroundColor : '#1993ff'"
             :stroke-width='strokeWidth' />
     </svg>
     <div
@@ -168,7 +170,7 @@ export default {
       return `M ${ this.x } ${ this.y } A ${ this.radius } ${ this.radius } 0 ${ this.largeArc } 1 ${ this.endX } ${ this.endY } ${ this.z }`;
     },
     valueStyle() {
-      let percentColor = this.validateColor(this.foregroundColor) ? this.foregroundColor : '#1993ff'
+      let percentColor = ( this.foregroundColor && this.validateColor(this.foregroundColor) ) ? this.foregroundColor : '#1993ff'
       let percentSize = ( this.customPercentSize && this.customPercentSize < 60 ) ? `${ this.customPercentSize }px` : false
       return {
         color: percentColor,
@@ -177,7 +179,7 @@ export default {
       };
     },
     customTextStyle() {
-      let textColor = this.validateColor(this.customTextColor) ? this.customTextColor : this.foregroundColor
+      let textColor = ( this.customTextColor && this.validateColor(this.customTextColor) ) ? this.customTextColor : this.foregroundColor
       let textWidth = this.strokeWidth ? `calc(100% - ${ this.strokeWidth * 2 }px)` : 'calc(100% - 20px)'
       let textPadding = ( this.strokeWidth && this.strokeWidth > 7 && this.strokeWidth <= 18 ) ? `0 ${ this.strokeWidth }px` : '0 10px'
       let textSize = ( this.customTextSize && this.customTextSize <= 22 ) ? `${ this.customTextSize }px` : false
@@ -194,7 +196,7 @@ export default {
       };
     }
   },
-  mounted () {
+  mounted() {
     if (this.valueCountUp && this.percent) {
       this.countUpPercent()
     }
@@ -215,7 +217,7 @@ export default {
       const totalFrames = Math.round(animationDuration / frameDuration); // Use that to calculate how many frames we need to complete the animation
       const easeOutQuad = t => t * ( 2 - t ); // An ease-out function that slows the count as it progresses
       let frame = 0; // The animation function, which takes an Element
-      const counter = setInterval(() =>  {
+      const counter = setInterval(() => {
         frame++
         const progress = easeOutQuad(frame / totalFrames) // Calculate our progress as a value between 0 and 1
         if (this.countingUpValue !== this.percent) {

--- a/src/DoughnutChart.vue
+++ b/src/DoughnutChart.vue
@@ -1,24 +1,43 @@
 <template>
-  <div class="doughnut_chart" style="position:relative;">
-    <svg :width="width" :height="height" viewBox="0 0 200 200" style="stroke-linecap:round;">
+  <div class='doughnut_chart' style='position:relative;'>
+    <svg :width='width' :height='height' viewBox='0 0 200 200' style='stroke-linecap:round;'>
       <!-- Background circle -->
-      <path :d="dBg" fill="transparent" :stroke="backgroundColor" :stroke-width="strokeWidth" />
+      <path :d='dBg' fill='transparent' :stroke='backgroundColor' :stroke-width='strokeWidth' />
       <!-- Move to start position, start drawing arc -->
-      <path :d="d" fill="transparent" :stroke="foregroundColor" :stroke-width="strokeWidth" />
+      <path :d='d' fill='transparent' :stroke='foregroundColor' :stroke-width='strokeWidth' />
     </svg>
-    <div v-if="visibleValue">
-      <template v-if="passTextAsHtml">
-        <div v-if="customText.length" :style="customTextStyle" v-html="customText"></div>
+    <div
+        v-if='visibleValue'
+        class='value-container'
+    >
+      <template v-if='passTextAsHtml'>
+        <div
+            v-if='customText.length'
+            :style='customTextStyle'
+            v-html='customText'
+        ></div>
       </template>
       <template v-else>
         <div
-          v-if="customText.length"
-          v-html="customText"
-          :class="classValue"
-          :style="customTextStyle"
-        ></div>
-        <span v-else-if="visibleEmptyText" :class="classValue" :style="valueStyle">{{ emptyText }}</span>
-        <span v-else :class="classValue" :style="valueStyle">{{ percent }}%</span>
+            v-if='customText.length'
+            v-html='customText'
+            :class='classValue'
+            :style='customTextStyle'
+        />
+        <p
+            v-else-if='visibleEmptyText'
+            :class='classValue'
+            :style='valueStyle'
+        >
+          {{ emptyText }}
+        </p>
+        <h1
+            v-else
+            :class='classValue'
+            :style='valueStyle'
+        >
+          {{ percent + '%' }}
+        </h1>
       </template>
     </div>
   </div>
@@ -74,6 +93,11 @@ export default {
     passTextAsHtml: {
       type: Boolean,
       default: false
+    },
+    customPercentSize: {
+      type: Number,
+      default: 40,
+      required: false
     }
   },
   data() {
@@ -103,21 +127,21 @@ export default {
     },
     // Calculate length of arc in radians
     radians() {
-      const degrees = (this.percent / 100) * 360;
+      const degrees = ( this.percent / 100 ) * 360;
       const value = degrees - 180; // Turn the circle 180 degrees counter clockwise
 
-      return (value * Math.PI) / 180;
+      return ( value * Math.PI ) / 180;
     },
     // If we reach full circle we need to complete the circle, this ties into the rounding error in X coordinate above
     z() {
       return parseInt(this.percent) === 100 ? "z" : "";
     },
     dBg() {
-      return `M ${this.x} ${this.y} A ${this.radius} ${this.radius} 0 1 1 ${this
-        .x - 0.0001} ${this.y} z`;
+      return `M ${ this.x } ${ this.y } A ${ this.radius } ${ this.radius } 0 1 1 ${ this
+          .x - 0.0001 } ${ this.y } z`;
     },
     d() {
-      return `M ${this.x} ${this.y} A ${this.radius} ${this.radius} 0 ${this.largeArc} 1 ${this.endX} ${this.endY} ${this.z}`;
+      return `M ${ this.x } ${ this.y } A ${ this.radius } ${ this.radius } 0 ${ this.largeArc } 1 ${ this.endX } ${ this.endY } ${ this.z }`;
     },
     valueFromBottom() {
       if (this.strokeWidth < 15) {
@@ -134,12 +158,10 @@ export default {
       }
     },
     valueStyle() {
+      let percentSize = (this.customPercentSize && this.customPercentSize < 60) ? this.customPercentSize : false
       return {
         color: this.foregroundColor,
-        bottom: `${this.valueFromBottom}px`,
-        left: `${this.valueFromLeft}px`,
-        position: "absolute",
-        "font-size": "18px"
+        fontSize: `${ percentSize }px`
       };
     },
     visibleEmptyText() {
@@ -148,10 +170,10 @@ export default {
     customTextStyle() {
       return {
         color: this.foregroundColor,
-        width: `${this.width - 6 * this.strokeWidth}px`,
-        height: `${this.height / 3}px`,
-        bottom: `${this.height / 2 - this.strokeWidth * 3}px`,
-        left: `${this.valueFromLeft / 3}px`,
+        width: `${ this.width - 6 * this.strokeWidth }px`,
+        height: `${ this.height / 3 }px`,
+        bottom: `${ this.height / 2 - this.strokeWidth * 3 }px`,
+        left: `${ this.valueFromLeft / 3 }px`,
         position: "absolute",
         verticalAlign: "middle",
         wordBreak: "break-all",
@@ -163,5 +185,21 @@ export default {
   }
 };
 </script>
+<style lang='scss' scoped>
+h1 {
+  margin: 0;
+  padding: 0;
+}
 
-
+.value-container {
+  display: flex;
+  flex-flow: column nowrap;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+</style>


### PR DESCRIPTION
Added more customizable props:

- Percent text size (max 60 to fit into the doughnut)
- Percent text color
- Percent count-up
- Percent count-up duration
- Label text size (max 22 to fit into the doughnut).
- Label text color
- Color validation (accepts HEX or CSS color values)

### Adding a lot of custom HTML code into the label might not fit into the doughnut.